### PR TITLE
Fix format-security warning/error

### DIFF
--- a/rtsp-server/xop/AACSource.cpp
+++ b/rtsp-server/xop/AACSource.cpp
@@ -72,7 +72,7 @@ string AACSource::GetAttribute() // RFC 3640
 			       "sizelength=13;indexlength=3;indexdeltalength=3;"
 			       "config=%02X%02X";
 	const size_t buf_size =
-		snprintf(nullptr, 0, rtpmap_fmt) + strlen(fmtp_fmt);
+		snprintf(nullptr, 0, rtpmap_fmt, samplerate_, channels_) + strlen(fmtp_fmt);
 	auto buf = vector<char>(buf_size);
 	const size_t rtpmap_format_size =
 		sprintf(buf.data(), rtpmap_fmt, samplerate_, channels_);


### PR DESCRIPTION
Fixes #58 
The absence of the formating of the two `%u` from `rtpmap_fmt` emits a warning which result in a error in with some distribution default flags.

This fix might need further testing.
I only tested by putting a video as a source in OBS start the RTSP stream and open it with VLC. The video and audio seems right.

Edit: with this fix it compiles on ArchLinux