### PR TITLE
Allow for compilation without the OBS frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(MACOS_BUNDLEID "com.scottxu.obs-rtspserver")
 set(OBS_PLUGIN_OBS_SOURCE_DIR ${CMAKE_SOURCE_DIR})
 set(OBS_FRONTEND_API_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/UI/obs-frontend-api")
 
-add_library(${CMAKE_PROJECT_NAME} MODULE)
+add_library(${PROJECT_NAME} MODULE)
 
 if (NOT COMMAND setup_plugin_target)
     include(external/BuildHelper.cmake)
@@ -61,28 +61,28 @@ set(OBS_RTSPSERVER_HEADERS
 	${OBS_RTSPSERVER_MAIN_HEADERS}
 	)
 
-set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY CXX_STANDARD 17)
-set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY C_STANDARD 17)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 17)
 
 find_qt(COMPONENTS Widgets Core)
 
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES AUTOMOC ON AUTOUIC ON AUTORCC ON)
+set_target_properties(${PROJECT_NAME} PROPERTIES AUTOMOC ON AUTOUIC ON AUTORCC ON)
 
-target_sources(${CMAKE_PROJECT_NAME} PRIVATE
+target_sources(${PROJECT_NAME} PRIVATE
 	${OBS_RTSPSERVER_SOURCES}
 	${OBS_RTSPSERVER_HEADERS})
 
 if(WIN32)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/rtspoutput.rc.in ${CMAKE_CURRENT_SOURCE_DIR}/rtspoutput.rc)
-	target_sources(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/rtspoutput.rc)
+	target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/rtspoutput.rc)
 endif()
 	
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
+target_include_directories(${PROJECT_NAME} PRIVATE
 	${OBS_FRONTEND_API_INCLUDE_DIRS}
 	${LIBOBS_INCLUDE_DIRS}
 	"rtsp-server")
 
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+target_link_libraries(${PROJECT_NAME} PRIVATE
 	rtsp-server
 	obs-frontend-api
 	libobs
@@ -92,17 +92,17 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
 add_definitions(-DVERSION_STRING="${OBS_PLUGUIN_VERSION}")
 
 if(APPLE)
-	set_target_properties(${CMAKE_PROJECT_NAME}
+	set_target_properties(${PROJECT_NAME}
 			PROPERTIES
 			FOLDER "plugins"
 			PRODUCTNAME "OBS RTSP Server Plugin")
 else()
-	set_target_properties(${CMAKE_PROJECT_NAME}
+	set_target_properties(${PROJECT_NAME}
 			PROPERTIES
 			FOLDER "plugins"
 			VERSION "${OBS_PLUGUIN_VERSION}"
 			PRODUCTNAME "OBS RTSP Server Plugin")
 endif()
 
-setup_plugin_target(${CMAKE_PROJECT_NAME})
+setup_plugin_target(${PROJECT_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,12 @@ set(OBS_RTSPSERVER_HEADERS
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
 set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 17)
 
-find_qt(COMPONENTS Widgets Core)
+if(ENABLE_UI)
+  find_qt(COMPONENTS Widgets Core)
+  set_target_properties(${PROJECT_NAME} PROPERTIES AUTOMOC ON AUTOUIC ON AUTORCC ON)
 
-set_target_properties(${PROJECT_NAME} PROPERTIES AUTOMOC ON AUTOUIC ON AUTORCC ON)
+  add_definitions(-DOBS_RTSPSERVER_ENABLE_UI)
+endif()
 
 target_sources(${PROJECT_NAME} PRIVATE
 	${OBS_RTSPSERVER_SOURCES}
@@ -78,16 +81,26 @@ if(WIN32)
 endif()
 	
 target_include_directories(${PROJECT_NAME} PRIVATE
-	${OBS_FRONTEND_API_INCLUDE_DIRS}
 	${LIBOBS_INCLUDE_DIRS}
 	"rtsp-server")
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
 	rtsp-server
-	obs-frontend-api
-	libobs
-	Qt::Core
-	Qt::Widgets)
+	libobs)
+
+if(ENABLE_UI)
+  # include all header files that are only relevant for OBS Studio
+	target_include_directories(${PROJECT_NAME} PRIVATE
+	    ${OBS_FRONTEND_API_INCLUDE_DIRS}
+  )
+
+  # link all obs frontend libraries
+	target_link_libraries(${PROJECT_NAME} PRIVATE
+		  obs-frontend-api
+		  Qt::Core
+		  Qt::Widgets
+  )
+endif()
 
 add_definitions(-DVERSION_STRING="${OBS_PLUGUIN_VERSION}")
 

--- a/external/BuildHelper.cmake
+++ b/external/BuildHelper.cmake
@@ -4,7 +4,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/external
 set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/release")
 set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${QTDIR};${DepsPath}")
 
-set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${OBS_PLUGUN_GIT_TAG}-linux")
+set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${OBS_PLUGUN_GIT_TAG}-linux")
 set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
 #set(CPACK_SOURCE_PACKAGE_FILE_NAME "${OBS_PLUGIN_PACKAGE_FILE_NAME}")
 set(MACOSX_PLUGIN_GUI_IDENTIFIER "${MACOS_BUNDLEID}")
@@ -44,14 +44,14 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/external/ObsPluginHelpers.cmake")
 
 if(OS_WINDOWS)
     if(MSVC)
-        target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE /W3)
+        target_compile_options(${PROJECT_NAME} PRIVATE /W3)
     endif()
 elseif(OS_MACOS)
     configure_file(
 		${CMAKE_SOURCE_DIR}/bundle/installer-macos.pkgproj.in
 		${CMAKE_SOURCE_DIR}/bundle/installer-macos.generated.pkgproj)
 
-    target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall)
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
 else()
-    target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall)
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
 endif()

--- a/external/BuildHelper.cmake
+++ b/external/BuildHelper.cmake
@@ -33,12 +33,14 @@ else()
 endif()
 add_library(libobs ALIAS OBS::libobs)
 
-find_package(obs-frontend-api REQUIRED)
-add_library(OBS::obs-frontend-api STATIC IMPORTED GLOBAL)
-set_target_properties(OBS::obs-frontend-api PROPERTIES
-    IMPORTED_LOCATION "${OBS_FRONTEND_API_LIB}"
-    )
-add_library(obs-frontend-api ALIAS OBS::obs-frontend-api)
+if(ENABLE_UI)
+	find_package(obs-frontend-api REQUIRED)
+	add_library(OBS::obs-frontend-api STATIC IMPORTED GLOBAL)
+	set_target_properties(OBS::obs-frontend-api PROPERTIES
+	    IMPORTED_LOCATION "${OBS_FRONTEND_API_LIB}"
+	)
+	add_library(obs-frontend-api ALIAS OBS::obs-frontend-api)
+endif()
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/external/ObsPluginHelpers.cmake")
 

--- a/rtsp-server/xop/CngMd5.cpp
+++ b/rtsp-server/xop/CngMd5.cpp
@@ -52,18 +52,19 @@ void CngMd5::GetMd5Hash(const unsigned char *data, const size_t dataSize,
 			unsigned char *outHash)
 {
 #if defined(WIN32) || defined(_WIN32)
+	BCRYPT_HASH_HANDLE hHash = nullptr;
+	PBYTE pbHashObject;
 	if (cbHash_ > MD5_HASH_LENGTH) {
 		LOG_ERROR("**** The generated hash value is too long");
 		goto Cleanup;
 	}
-	const auto pbHashObject = static_cast<PBYTE>(
+	pbHashObject = static_cast<PBYTE>(
 		HeapAlloc(GetProcessHeap(), 0, cbHashObject_));
 	if (nullptr == pbHashObject) {
 		LOG_ERROR("**** memory allocation failed");
 		goto Cleanup;
 	}
 	//create a hash
-	BCRYPT_HASH_HANDLE hHash = nullptr;
 	NTSTATUS status;
 	if (!NT_SUCCESS(status = BCryptCreateHash(hAlgorithm_, &hHash,
 						  pbHashObject, cbHashObject_,

--- a/rtsp_frontend.cpp
+++ b/rtsp_frontend.cpp
@@ -1,0 +1,111 @@
+#ifdef OBS_RTSPSERVER_ENABLE_UI
+#include "rtsp_frontend.h"
+
+#include <util/config-file.h>
+#include <mutex>
+#include "helper.h"
+#include "rtsp_output_helper.h"
+#include "ui/rtsp_properties.hpp"
+#include <obs-frontend-api.h>
+#include <QMainWindow>
+#include <QAction>
+
+void obs_frontend_event(enum obs_frontend_event event, void *ptr);
+void rtsp_output_auto_start(RtspOutputHelper *rtspOutputHelper);
+void rtsp_output_stop(RtspOutputHelper *rtspOutputHelper);
+void rtsp_output_save_settings(RtspOutputHelper *rtspOutputHelper);
+void rtsp_output_save_hotkey_settings(RtspOutputHelper *rtspOutputHelper);
+
+void rtsp_frontend_load()
+{
+	RtspOutputHelper *rtspOutputHelper;
+	{
+		auto *settings = rtsp_output_read_data();
+		auto *config = rtsp_properties_open_config();
+		const char *str = nullptr;
+		str = config_get_string(config, HOTKEY_CONFIG_SECTIION,
+					"RtspOutput");
+		obs_data_t *hotkey = nullptr;
+		if (str)
+			hotkey = obs_data_create_from_json(str);
+		rtspOutputHelper =
+			RtspOutputHelper::CreateRtspOutput(settings, hotkey);
+		obs_data_release(hotkey);
+		config_close(config);
+		obs_data_release(settings);
+	}
+
+	const auto mainWindow =
+		static_cast<QMainWindow *>(obs_frontend_get_main_window());
+	const auto action =
+		static_cast<QAction *>(obs_frontend_add_tools_menu_qaction(
+			obs_module_text("RtspServer")));
+
+	obs_frontend_push_ui_translation(obs_module_get_string);
+	const auto rtspProperties = new RtspProperties(
+		rtspOutputHelper->GetOutputName(), mainWindow);
+	obs_frontend_pop_ui_translation();
+
+	QAction::connect(action, &QAction::triggered, rtspProperties,
+			 &QDialog::exec);
+
+	obs_frontend_add_event_callback(obs_frontend_event, rtspOutputHelper);
+}
+
+void rtsp_frontend_unload()
+{
+	obs_frontend_remove_event_callback(obs_frontend_event, nullptr);
+}
+
+void obs_frontend_event(enum obs_frontend_event event, void* ptr)
+{
+	const auto rtspOutputHelper = static_cast<RtspOutputHelper *>(ptr);
+	switch (event) {
+	case OBS_FRONTEND_EVENT_FINISHED_LOADING:
+		rtsp_output_auto_start(rtspOutputHelper);
+		break;
+	case OBS_FRONTEND_EVENT_EXIT:
+		rtsp_output_stop(rtspOutputHelper);
+		rtsp_output_save_settings(rtspOutputHelper);
+		rtsp_output_save_hotkey_settings(rtspOutputHelper);
+		delete rtspOutputHelper;
+		break;
+	default:;
+	}
+}
+
+void rtsp_output_auto_start(RtspOutputHelper *rtspOutputHelper)
+{
+	auto *config = rtsp_properties_open_config();
+	auto autoStart = false;
+	if (config) {
+		autoStart =
+			config_get_bool(config, CONFIG_SECTIION, "AutoStart");
+		config_close(config);
+	}
+	if (autoStart)
+		rtspOutputHelper->Start();
+}
+
+void rtsp_output_stop(RtspOutputHelper *rtspOutputHelper)
+{
+	rtspOutputHelper->Stop();
+}
+
+void rtsp_output_save_hotkey_settings(RtspOutputHelper *rtspOutputHelper)
+{
+	auto *data = rtspOutputHelper->HotkeysSave();
+	auto *str = obs_data_get_json(data);
+	auto *config = rtsp_properties_open_config();
+	config_set_string(config, HOTKEY_CONFIG_SECTIION, "RtspOutput", str);
+	config_save(config);
+	config_close(config);
+}
+
+void rtsp_output_save_settings(RtspOutputHelper *rtspOutputHelper)
+{
+	auto *data = rtspOutputHelper->GetSettings();
+	rtsp_output_save_data(data);
+}
+
+#endif // OBS_RTSPSERVER_ENABLE_UI

--- a/rtsp_frontend.h
+++ b/rtsp_frontend.h
@@ -1,0 +1,9 @@
+#ifdef OBS_RTSPSERVER_ENABLE_UI
+#ifndef RTSP_FRONTEND_H
+#define RTSP_FRONTEND_H
+
+void rtsp_frontend_load();
+void rtsp_frontend_unload();
+
+#endif // RTSP_FRONTEND_H
+#endif // OBS_RTSPSERVER_ENABLE_UI

--- a/rtsp_main.cpp
+++ b/rtsp_main.cpp
@@ -1,23 +1,11 @@
 #include <obs-module.h>
-#include <obs-frontend-api.h>
-#include <util/config-file.h>
-#include <QMainWindow>
-#include <QAction>
-#include <mutex>
 #include <net/Logger.h>
-#include "helper.h"
-#include "rtsp_output_helper.h"
 #include "rtsp_output.h"
-#include "ui/rtsp_properties.hpp"
+#include "rtsp_frontend.h"
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-rtspserver", "en-US")
 
-void obs_frontend_event(enum obs_frontend_event event, void *ptr);
-void rtsp_output_auto_start(RtspOutputHelper *rtspOutputHelper);
-void rtsp_output_stop(RtspOutputHelper *rtspOutputHelper);
-void rtsp_output_save_settings(RtspOutputHelper *rtspOutputHelper);
-void rtsp_output_save_hotkey_settings(RtspOutputHelper *rtspOutputHelper);
 void server_log_write_callback(xop::Priority priority, std::string info);
 
 const char *obs_module_name(void)
@@ -35,91 +23,18 @@ bool obs_module_load(void)
 	xop::Logger::Instance().SetWriteCallback(server_log_write_callback);
 	rtsp_output_register();
 
-	RtspOutputHelper *rtspOutputHelper;
-	{
-		auto *settings = rtsp_output_read_data();
-		auto *config = rtsp_properties_open_config();
-		const char *str = nullptr;
-		str = config_get_string(config, HOTKEY_CONFIG_SECTIION,
-					"RtspOutput");
-		obs_data_t *hotkey = nullptr;
-		if (str) hotkey = obs_data_create_from_json(str);
-		rtspOutputHelper =
-			RtspOutputHelper::CreateRtspOutput(settings, hotkey);
-		obs_data_release(hotkey);
-		config_close(config);
-		obs_data_release(settings);
-	}
-
-	const auto mainWindow = static_cast<QMainWindow *>(obs_frontend_get_main_window());
-	const auto action = static_cast<QAction *>(obs_frontend_add_tools_menu_qaction(
-		obs_module_text("RtspServer")));
-
-	obs_frontend_push_ui_translation(obs_module_get_string);
-	const auto rtspProperties = new RtspProperties(rtspOutputHelper->GetOutputName(), mainWindow);
-	obs_frontend_pop_ui_translation();
-
-	QAction::connect(action, &QAction::triggered, rtspProperties, &QDialog::exec);
-
-	obs_frontend_add_event_callback(obs_frontend_event, rtspOutputHelper);
+#ifdef OBS_RTSPSERVER_ENABLE_UI
+	rtsp_frontend_load();
+#endif
 
 	return true;
 }
 
 void obs_module_unload(void)
 {
-	obs_frontend_remove_event_callback(obs_frontend_event, nullptr);
-}
-
-void obs_frontend_event(enum obs_frontend_event event, void *ptr)
-{
-	const auto rtspOutputHelper = static_cast<RtspOutputHelper *>(ptr);
-	switch (event) {
-	case OBS_FRONTEND_EVENT_FINISHED_LOADING:
-		rtsp_output_auto_start(rtspOutputHelper);
-		break;
-	case OBS_FRONTEND_EVENT_EXIT:
-		rtsp_output_stop(rtspOutputHelper);
-		rtsp_output_save_settings(rtspOutputHelper);
-		rtsp_output_save_hotkey_settings(rtspOutputHelper);
-		delete rtspOutputHelper;
-		break;
-	default: ;
-	}
-}
-
-void rtsp_output_auto_start(RtspOutputHelper *rtspOutputHelper)
-{
-	auto *config = rtsp_properties_open_config();
-	auto autoStart = false;
-	if (config) {
-		autoStart =
-			config_get_bool(config, CONFIG_SECTIION, "AutoStart");
-		config_close(config);
-	}
-	if (autoStart)
-		rtspOutputHelper->Start();
-}
-
-void rtsp_output_stop(RtspOutputHelper *rtspOutputHelper)
-{
-	rtspOutputHelper->Stop();
-}
-
-void rtsp_output_save_hotkey_settings(RtspOutputHelper *rtspOutputHelper)
-{
-	auto *data = rtspOutputHelper->HotkeysSave();
-	auto *str = obs_data_get_json(data);
-	auto *config = rtsp_properties_open_config();
-	config_set_string(config, HOTKEY_CONFIG_SECTIION, "RtspOutput", str);
-	config_save(config);
-	config_close(config);
-}
-
-void rtsp_output_save_settings(RtspOutputHelper *rtspOutputHelper)
-{
-	auto *data = rtspOutputHelper->GetSettings();
-	rtsp_output_save_data(data);
+#ifdef OBS_RTSPSERVER_ENABLE_UI
+	rtsp_frontend_unload();
+#endif
 }
 
 void server_log_write_callback(xop::Priority priority, std::string info)

--- a/rtsp_output_helper.cpp
+++ b/rtsp_output_helper.cpp
@@ -1,3 +1,4 @@
+#ifdef OBS_RTSPSERVER_ENABLE_UI
 #include <vector>
 #include <cstdio>
 #include <obs-module.h>
@@ -198,3 +199,5 @@ void RtspOutputHelper::OnPreStartSignal(void *data, calldata_t *cd)
 	const auto helper = static_cast<RtspOutputHelper *>(data);
 	helper->UpdateEncoder();
 }
+
+#endif // OBS_RTSPSERVER_ENABLE_UI

--- a/rtsp_output_helper.h
+++ b/rtsp_output_helper.h
@@ -1,3 +1,4 @@
+#ifdef OBS_RTSPSERVER_ENABLE_UI
 #ifndef RTSP_OUTPUT_HELPER_H
 #define RTSP_OUTPUT_HELPER_H
 
@@ -44,3 +45,4 @@ private:
 };
 
 #endif // RTSP_OUTPUT_HELPER_H
+#endif // OBS_RTSPSERVER_ENABLE_UI

--- a/ui/rtsp_properties.cpp
+++ b/ui/rtsp_properties.cpp
@@ -1,3 +1,4 @@
+#ifdef OBS_RTSPSERVER_ENABLE_UI
 #include <obs-frontend-api.h>
 #include <util/config-file.h>
 #include <QMainWindow>
@@ -318,3 +319,5 @@ void RtspProperties::SaveConfig(config_t *config) const
 			ui->checkBoxAudioTrack6->isChecked());
 	config_save(config);
 }
+
+#endif // OBS_RTSPSERVER_ENABLE_UI

--- a/ui/rtsp_properties.hpp
+++ b/ui/rtsp_properties.hpp
@@ -1,3 +1,4 @@
+#ifdef OBS_RTSPSERVER_ENABLE_UI
 #ifndef RTSP_PROPERTIES_H
 #define RTSP_PROPERTIES_H
 
@@ -65,3 +66,4 @@ private:
 };
 
 #endif // RTSP_PROPERTIES_H
+#endif // OBS_RTSPSERVER_ENABLE_UI


### PR DESCRIPTION
As suggested in discussion #138 this change uses the CMake variable "ENABLE_UI" which is already defined by the obs-studio top-level project to allow for compilation without the obs frontend libraries and dependencies.

This Pull Request has three separate changes each contained in a separate commit:

- **adaced3**: This commit replaces all occurrences of "CMAKE_PROJECT_NAME" with "PROJECT_NAME" in the Build Files. This is necessary because as of CMake 3.12, the variable CMAKE_PROJECT_NAME refers to the top-level project name which is "obs-studio" because the plugin is a sub-project of obs. PROJECT_NAME refers to the current project which is obs-rtspserver as intended.
- **2710c7b**: This commit contains the necessary changes to enable compilation without the frontend. Besides the changes in the CMakeLists, I use a preprocessor definition (OBS_RTSPSERVER_ENABLE_UI) to decide whether to compile / run certain frontend sources files or not.
- **6ce0d09**: Last but not least while testing with the MSVC compiler I encountered a compilation error with the rtsp-server/xop/CngMd5.cpp file due to the fact that a "goto" statement cannot jump over local variable declaration statements. This is also fixed this commit.

One can use the non-frontend version of the plugin by creating an obs-output with output type "rtsp_output", setting the desired properties and attaching a custom video and audio encoder.