### PR TITLE
added usage section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,29 @@ rm -rf ~/obs-rtspserver-linux
 * Add `add_subdirectory(obs-rtspserver)` to (obs-studio source code)/plugins/CMakeLists.txt
 * Build obs-rtspserver.
 
+# Usage
+## Starting the RTSP Server
+1. Open OBS Studio and go to Tools → RTSP Server
+2. Configure the server settings (port, authentication, etc.)
+3. Click Start to start the RTSP server
+
+### Important: Automatic Stream Activation
+The RTSP stream is automatically active once the RTSP server is started. You do NOT need to use OBS Studio's "Start Streaming" button. The stream is automatically available based on your current scene and source settings.
+
+### Accessing the Stream
+```
+rtsp://{server-ip}:{port}/{path}
+
+## if all defaults:
+rtsp://{server-ip}:554/live
+```
+You can test the stream using media players like VLC, FFmpeg, or any RTSP-compatible client.
+
+### Notes
+* The RTSP server runs independently from OBS Studio's built-in streaming functionality
+* The stream reflects whatever is currently shown in your OBS preview (active scene)
+* The server will continue running until you stop it manually or close OBS Studio
+
 # FAQ
 * [Can't find the plugin in the menu](https://github.com/iamscottxu/obs-rtspserver/wiki/FAQ#cant-find-the-plugin-in-the-menu)
 

--- a/README_de-DE.md
+++ b/README_de-DE.md
@@ -96,6 +96,29 @@ rm -rf ~/obs-rtspserver-linux
 * Fügen Sie `add_subdirectory(obs-rtspserver)` zu (obs-studio Quellcode)/plugins/CMakeLists.txt hinzu.
 * Build obs-rtspserver.
 
+# Verwendung
+## RTSP Server starten
+1. OBS Studio öffnen und im Menü: Tools → RTSP Server
+2. Server Einstellungen konfigurieren (Port, Authentifizierung, etc.)
+3. Start klicken um den RTSP server zu starten
+
+### Achtung!: Stream automatisch aktiv
+Der RTSP stream ist automatisch aktiv, sobald der RTSP server gestartet ist. Sie müssen NICHT den OBS Studio's "Start Streaming" Button verwenden. Der stream ist automatisch verfügbar, basierend auf der aktuellen Szene und Einstellungen
+
+### Den Stream abrufen
+```
+rtsp://{server-ip}:{port}/{path}
+
+## if all defaults:
+rtsp://{server-ip}:554/live
+```
+Der Stream kann mit VLC, FFmpeg oder jedem anderen RTSP Client getested werden
+
+### Hinweise
+* Der RTSP server läuft unabhängig von OBS Studio's eingebauter streaming Funktionalität
+* Der stream beinhaltet direkt was in dem OBS Vorschaufenster gezeigt wird (aktive Szene)
+* Der server läuft so lange, bis OBS Studio geschlossen wird oder der server gestoppt wird
+
 # FAQ
 * [Kann das Plugin im Menü nicht finden](https://github.com/iamscottxu/obs-rtspserver/wiki/FAQ#cant-find-the-plugin-in-the-menu)
 


### PR DESCRIPTION
As a first-time OBS Studio user, I spent approx. 30 minutes confused because I didn't realize the stream was already running after starting the RTSP server through the plugin dialog. 
I kept looking for the correct rtmp URL in my stream settings. 
This addition should help other new users avoid the same confusion.